### PR TITLE
Add Windows support

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -102,7 +102,7 @@ function calculateBindings(sourceMaps: SourceMap[], stackTrace: null | StackTrac
 }
 
 function extractFileNameFromPath(path: string): string {
-  const parts = path.split('/')
+  const parts = path.split(/[/\\]/)
   return parts[parts.length - 1]
 }
 


### PR DESCRIPTION
Adds support for the Windows path separator.

The following now works:
```
Error: Test
    at C:\example\folder\output.js:822:11
```